### PR TITLE
enable dac-server

### DIFF
--- a/src/cl/op-node/op_node_launcher.star
+++ b/src/cl/op-node/op_node_launcher.star
@@ -90,6 +90,28 @@ def launch(
         participant.cl_log_level, global_log_level, VERBOSITY_LEVELS
     )
 
+    dac_cmd = [
+        "da-server",
+        "da",
+        "start", 
+        "--config /usr/local/bin/default.json",
+    ]
+    dac_ports = {
+        constants.HTTP_PORT_ID: ethereum_package_shared_utils.new_port_spec(
+            8888,
+            ethereum_package_shared_utils.TCP_PROTOCOL,
+            ethereum_package_shared_utils.HTTP_APPLICATION_PROTOCOL,
+        ),
+    }
+    dac_config = {
+        # participant.cl_image contains binaries for both op-node and da-server.
+        # Check op-stack-go/Dockerfile in monorepo for details.
+        "image": participant.cl_image,
+        "ports": dac_ports,
+        "cmd": dac_cmd,
+    }
+    plan.add_service("dac-for-{0}".format(service_name), dac_config)
+
     config = get_beacon_config(
         plan,
         launcher,
@@ -184,6 +206,7 @@ def get_beacon_config(
         "--safedb.path={0}".format(BEACON_DATA_DIRPATH_ON_SERVICE_CONTAINER),
         "--altda.enabled=" + str(da_server_context.enabled),
         "--altda.da-server=" + da_server_context.http_url,
+        "--dac.urls=http://localhost:8888",
     ]
 
     # configure files


### PR DESCRIPTION
This PR finishes item 3 of https://github.com/QuarkChain/optimism/issues/26.

It mimics the `dac-server` service in the old devnet [here](https://github.com/QuarkChain/optimism/blob/beta_contracts/ops-bedrock/docker-compose.yml).